### PR TITLE
Brand migration: Update org references ambiware-labs → loqalabs

### DIFF
--- a/src/components/layout/SiteFooter.vue
+++ b/src/components/layout/SiteFooter.vue
@@ -8,7 +8,7 @@
         </p>
       </div>
       <div class="flex flex-col gap-2 text-sm text-white/60">
-        <a href="https://github.com/ambiware-labs" target="_blank" rel="noopener" class="hover:text-white">GitHub</a>
+        <a href="https://github.com/loqalabs" target="_blank" rel="noopener" class="hover:text-white">GitHub</a>
         <a href="mailto:hello@ambiware.ai" class="hover:text-white">hello@ambiware.ai</a>
         <span class="text-white/40">Loqa is an Ambiware Labs project.</span>
       </div>

--- a/src/components/layout/SiteHeader.vue
+++ b/src/components/layout/SiteHeader.vue
@@ -25,10 +25,10 @@ const navMenuSections: NavGroup[] = [
   {
     name: 'Get started',
     items: [
-      { name: 'Quickstart on GitHub', href: 'https://github.com/ambiware-labs/loqa-core/blob/main/docs/GETTING_STARTED.md', external: true },
-      { name: 'Runtime README', href: 'https://github.com/ambiware-labs/loqa-core', external: true },
-      { name: 'Extension Labs', href: 'https://github.com/ambiware-labs/loqa-meta/blob/main/community/extension-labs/README.md', external: true },
-      { name: 'Loqa core discussions', href: 'https://github.com/ambiware-labs/loqa-core/discussions', external: true }
+      { name: 'Quickstart on GitHub', href: 'https://github.com/loqalabs/loqa-core/blob/main/docs/GETTING_STARTED.md', external: true },
+      { name: 'Runtime README', href: 'https://github.com/loqalabs/loqa-core', external: true },
+      { name: 'Extension Labs', href: 'https://github.com/loqalabs/loqa-meta/blob/main/community/extension-labs/README.md', external: true },
+      { name: 'Loqa core discussions', href: 'https://github.com/loqalabs/loqa-core/discussions', external: true }
     ]
   },
   {
@@ -43,8 +43,8 @@ const navMenuSections: NavGroup[] = [
   {
     name: 'Community',
     items: [
-      { name: 'Roadmap', href: 'https://github.com/ambiware-labs/loqa-meta/blob/main/roadmap/MVP_BACKLOG.md', external: true },
-      { name: 'Governance', href: 'https://github.com/ambiware-labs/loqa-meta/tree/main/governance', external: true },
+      { name: 'Roadmap', href: 'https://github.com/loqalabs/loqa-meta/blob/main/roadmap/MVP_BACKLOG.md', external: true },
+      { name: 'Governance', href: 'https://github.com/loqalabs/loqa-meta/tree/main/governance', external: true },
       { name: 'Blog', to: '/blog' },
       { name: 'Docs hub', to: '/docs' }
     ]

--- a/src/content/blog/posts.ts
+++ b/src/content/blog/posts.ts
@@ -25,15 +25,15 @@ export const posts: BlogPost[] = [
 <p>
   The Loqa runtime, protocols, skills host, and tooling remain permanently MIT-licensed. Anyone can run, fork, or extend the stack on
   their own hardware—no feature gates, no cloud lock-in. Governance, security policy, and RFCs all live in the open at
-  <a href="https://github.com/ambiware-labs/loqa-meta">loqa-meta</a>.
+  <a href="https://github.com/loqalabs/loqa-meta">loqa-meta</a>.
 </p>
 
 <h3>Modular extensibility</h3>
 <p>
   Skills and adapters behave like VS Code extensions or WordPress plugins. The new
-  <a href="https://github.com/ambiware-labs/loqa-core/blob/main/docs/skills/SPEC.md">skills specification</a> documents the
+  <a href="https://github.com/loqalabs/loqa-core/blob/main/docs/skills/SPEC.md">skills specification</a> documents the
   manifest schema and host ABI so third-party creators can experiment freely. We’re also bootstrapping
-  <a href="https://github.com/ambiware-labs/loqa-meta/issues/27">Extension Labs</a> resources to showcase community work and share
+  <a href="https://github.com/loqalabs/loqa-meta/issues/27">Extension Labs</a> resources to showcase community work and share
   starter kits.
 </p>
 
@@ -41,19 +41,19 @@ export const posts: BlogPost[] = [
 <p>
   To keep the lights on, Ambiware Labs will offer optional services that never compromise privacy: managed updates, premium skill packs,
   and curated hardware bundles. We’re drafting the first wave in
-  <a href="https://github.com/ambiware-labs/loqa-meta/issues/28">our value-add roadmap</a> and laying the groundwork for a
-  <a href="https://github.com/ambiware-labs/loqa-meta/issues/26">marketplace RFC</a> so creators can monetize their skills alongside us.
+  <a href="https://github.com/loqalabs/loqa-meta/issues/28">our value-add roadmap</a> and laying the groundwork for a
+  <a href="https://github.com/loqalabs/loqa-meta/issues/26">marketplace RFC</a> so creators can monetize their skills alongside us.
 </p>
 
 <p>
   This hybrid approach gives Loqa the resilience of Blender, the modular energy of Home Assistant, and the sustainability of OBS +
   Streamlabs—all while staying unapologetically weird. Join the discussion in
-  <a href="https://github.com/ambiware-labs/loqa-core/discussions">GitHub Discussions</a> and help shape what comes next.
+  <a href="https://github.com/loqalabs/loqa-core/discussions">GitHub Discussions</a> and help shape what comes next.
 </p>
 `
   },
   {
-    slug: 'ambiware-labs-loqa-launch',
+    slug: 'loqalabs-loqa-launch',
     title: 'Announcing Ambiware Labs + Loqa',
     date: 'September 25, 2025',
     author: 'Ambiware Labs Team',

--- a/src/views/DocsView.vue
+++ b/src/views/DocsView.vue
@@ -20,11 +20,11 @@ const sections = [
     links: [
       {
         label: 'Read the full guide',
-        href: 'https://github.com/ambiware-labs/loqa-core/blob/main/docs/INSTALLATION.md'
+        href: 'https://github.com/loqalabs/loqa-core/blob/main/docs/INSTALLATION.md'
       },
       {
         label: 'Download nightly builds',
-        href: 'https://github.com/ambiware-labs/loqa-core/actions/workflows/nightly.yml'
+        href: 'https://github.com/loqalabs/loqa-core/actions/workflows/nightly.yml'
       }
     ]
   },
@@ -46,7 +46,7 @@ const sections = [
     links: [
       {
         label: 'Open quickstart',
-        href: 'https://github.com/ambiware-labs/loqa-core/blob/main/docs/GETTING_STARTED.md'
+        href: 'https://github.com/loqalabs/loqa-core/blob/main/docs/GETTING_STARTED.md'
       }
     ]
   },
@@ -68,7 +68,7 @@ const sections = [
     links: [
       {
         label: 'View architecture doc',
-        href: 'https://github.com/ambiware-labs/loqa-core/blob/main/docs/ARCHITECTURE.md'
+        href: 'https://github.com/loqalabs/loqa-core/blob/main/docs/ARCHITECTURE.md'
       }
     ]
   },
@@ -86,11 +86,11 @@ const sections = [
     links: [
       {
         label: 'Read the positioning update',
-        href: 'https://github.com/ambiware-labs/.github'
+        href: 'https://github.com/loqalabs/.github'
       },
       {
         label: 'Follow the marketplace RFC',
-        href: 'https://github.com/ambiware-labs/loqa-meta/issues/26'
+        href: 'https://github.com/loqalabs/loqa-meta/issues/26'
       }
     ]
   }

--- a/src/views/GettingStartedView.vue
+++ b/src/views/GettingStartedView.vue
@@ -22,7 +22,7 @@ const steps: Step[] = [
     title: 'Clone and prepare',
     description: 'Clone the runtime repository and build the TinyGo sample skills.',
     commands: [
-      'git clone https://github.com/ambiware-labs/loqa-core.git',
+      'git clone https://github.com/loqalabs/loqa-core.git',
       'cd loqa-core',
       'make skills',
     ],
@@ -85,7 +85,7 @@ const steps: Step[] = [
       </p>
       <div class="mt-4 flex flex-wrap gap-3">
         <a
-          href="https://github.com/ambiware-labs/loqa-core/blob/main/docs/GETTING_STARTED.md"
+          href="https://github.com/loqalabs/loqa-core/blob/main/docs/GETTING_STARTED.md"
           target="_blank"
           rel="noopener"
           class="cta-button inline-flex"

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -11,17 +11,17 @@ const pillars = [
   {
     title: 'Composable Open Core',
     description: 'The MIT-licensed runtime, skills host, and tooling stay open forever—compose whatever ambient stack you need.',
-    href: 'https://github.com/ambiware-labs/loqa-core'
+    href: 'https://github.com/loqalabs/loqa-core'
   },
   {
     title: 'Modular extensibility',
     description: 'Skills, adapters, and automations plug into Loqa like VS Code extensions or WordPress plugins, ready for community creativity.',
-    href: 'https://github.com/ambiware-labs/loqa-meta/tree/main/community'
+    href: 'https://github.com/loqalabs/loqa-meta/tree/main/community'
   },
   {
     title: 'Loqa Studio add-ons',
     description: 'Optional Studio persona packs, encrypted Loqa Cloud sync, and support plans keep Loqa sustainable without locking anything down.',
-    href: 'https://github.com/ambiware-labs/loqa-meta/issues/25'
+    href: 'https://github.com/loqalabs/loqa-meta/issues/25'
   }
 ]
 
@@ -96,7 +96,7 @@ const meshAreas = [
       'Whisper Tiny streaming ASR',
       'Local automations + sensors'
     ],
-    href: 'https://github.com/ambiware-labs/loqa-meta/tree/main/community',
+    href: 'https://github.com/loqalabs/loqa-meta/tree/main/community',
     icon: 'edge'
   },
   {
@@ -108,7 +108,7 @@ const meshAreas = [
       'Planner LLM with deterministic tools',
       'Observability baked in (Grafana, Loki, Tempo)'
     ],
-    href: 'https://github.com/ambiware-labs/loqa-core',
+    href: 'https://github.com/loqalabs/loqa-core',
     icon: 'core'
   },
   {
@@ -120,7 +120,7 @@ const meshAreas = [
       'Loqa Cloud for encrypted sync',
       'Support plans and marketplace ecosystem'
     ],
-    href: 'https://github.com/ambiware-labs/loqa-meta/issues/25',
+    href: 'https://github.com/loqalabs/loqa-meta/issues/25',
     icon: 'studio'
   }
 ]
@@ -172,25 +172,25 @@ const communityLinks = [
   {
     title: 'Read the roadmap',
     description: 'Track Workstream progress and MVP milestones.',
-    href: 'https://github.com/ambiware-labs/loqa-meta/blob/main/roadmap/MVP_BACKLOG.md',
+    href: 'https://github.com/loqalabs/loqa-meta/blob/main/roadmap/MVP_BACKLOG.md',
     icon: 'roadmap'
   },
   {
     title: 'Contributor guide',
     description: 'Find starter issues, publish skills, or propose an RFC.',
-    href: 'https://github.com/ambiware-labs/loqa-meta/blob/main/community/contributing-guide.md',
+    href: 'https://github.com/loqalabs/loqa-meta/blob/main/community/contributing-guide.md',
     icon: 'guide'
   },
   {
     title: 'Extension Labs',
     description: 'Templates and checklists for building Loqa skills.',
-    href: 'https://github.com/ambiware-labs/loqa-meta/blob/main/community/extension-labs/README.md',
+    href: 'https://github.com/loqalabs/loqa-meta/blob/main/community/extension-labs/README.md',
     icon: 'labs'
   },
   {
     title: 'Partner outreach',
     description: 'Collaborate on hardware kits, courses, or co-marketing.',
-    href: 'https://github.com/ambiware-labs/loqa-meta/blob/main/community/outreach/partner_pipeline.md',
+    href: 'https://github.com/loqalabs/loqa-meta/blob/main/community/outreach/partner_pipeline.md',
     icon: 'partners'
   }
 ]
@@ -232,14 +232,14 @@ const samplePack = {
                 <path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75L21 10.5m0 0l-3.75 3.75M21 10.5H3" />
               </svg>
             </RouterLink>
-            <a href="https://github.com/ambiware-labs/loqa-core" class="cta-button secondary" target="_blank" rel="noopener">
+            <a href="https://github.com/loqalabs/loqa-core" class="cta-button secondary" target="_blank" rel="noopener">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-4 w-4">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5" />
               </svg>
               <span>View the runtime on GitHub</span>
             </a>
-            <a href="https://github.com/ambiware-labs/loqa-core/blob/main/docs/GETTING_STARTED.md" class="cta-button secondary" target="_blank" rel="noopener">
+            <a href="https://github.com/loqalabs/loqa-core/blob/main/docs/GETTING_STARTED.md" class="cta-button secondary" target="_blank" rel="noopener">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-4 w-4">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5h7.5m-7.5 0A2.25 2.25 0 006 6.75v10.5A2.25 2.25 0 008.25 19.5h7.5A2.25 2.25 0 0018 17.25V6.75A2.25 2.25 0 0015.75 4.5m-7.5 0V3.75A1.5 1.5 0 019.75 2.25h4.5a1.5 1.5 0 011.5 1.5V4.5" />
               </svg>
@@ -519,7 +519,7 @@ const samplePack = {
         <div class="mt-6 grid gap-6 md:grid-cols-2">
           <div class="space-y-4">
             <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-brand-blue/80">Kickstart commands</h3>
-            <CommandSnippet command="git clone https://github.com/ambiware-labs/loqa-core.git" />
+            <CommandSnippet command="git clone https://github.com/loqalabs/loqa-core.git" />
             <CommandSnippet command="cd loqa-core && make skills && make run" />
           </div>
           <div class="space-y-4">
@@ -538,13 +538,13 @@ mounts:
           </div>
         </div>
         <div class="mt-8 flex flex-wrap gap-4">
-          <a href="https://github.com/ambiware-labs/loqa-meta/blob/main/roadmap/MVP_BACKLOG.md" class="cta-button secondary" target="_blank" rel="noopener">
+          <a href="https://github.com/loqalabs/loqa-meta/blob/main/roadmap/MVP_BACKLOG.md" class="cta-button secondary" target="_blank" rel="noopener">
             View the MVP backlog
           </a>
-          <a href="https://github.com/ambiware-labs/loqa-core/discussions" class="cta-button" target="_blank" rel="noopener">
+          <a href="https://github.com/loqalabs/loqa-core/discussions" class="cta-button" target="_blank" rel="noopener">
             Join the community
           </a>
-          <a href="https://github.com/ambiware-labs/loqa-meta/blob/main/community/extension-labs/README.md" class="cta-button secondary" target="_blank" rel="noopener">
+          <a href="https://github.com/loqalabs/loqa-meta/blob/main/community/extension-labs/README.md" class="cta-button secondary" target="_blank" rel="noopener">
             Explore Extension Labs
           </a>
         </div>
@@ -588,7 +588,7 @@ mounts:
         <p class="mt-3 max-w-3xl text-white/70">
           Loqa runs locally, ships with zero telemetry, and only syncs to Loqa Cloud when you explicitly opt in. Read the
           <a
-            href="https://github.com/ambiware-labs/loqa-meta/blob/main/governance/privacy.md"
+            href="https://github.com/loqalabs/loqa-meta/blob/main/governance/privacy.md"
             class="text-brand-blue hover:text-white"
             target="_blank"
             rel="noopener"


### PR DESCRIPTION
Updates all references from ambiware-labs to loqalabs as part of brand migration.

Migration Phase: Phase 2.3 - Repository Updates